### PR TITLE
overhaul terrain generation backend + add minerals + tweaks

### DIFF
--- a/IslandMUD-server/constants.cpp
+++ b/IslandMUD-server/constants.cpp
@@ -7,8 +7,8 @@ Feb 14, 2015 */
 const int C::GROUND_INDEX = 3; // there are three levels below this
 const int C::VIEW_DISTANCE = 9; // 5+1+5 to a side == 11*11 total area
 
-const int C::WORLD_X_DIMENSION = 100;
-const int C::WORLD_Y_DIMENSION = 100;
+const int C::WORLD_X_DIMENSION = 1000;
+const int C::WORLD_Y_DIMENSION = 1000;
 const int C::WORLD_Z_DIMENSION = 8;
 
 const int C::DEFAULT_SPAWN_X = C::WORLD_X_DIMENSION / 2; // N/S center
@@ -22,7 +22,6 @@ const string C::game_directory = "C:/IslandMUD";
 const string C::game_directory = "/home/IslandMUD";
 #endif
 const string C::world_terrain_file_location = C::game_directory + "/world_terrain.txt";
-const string C::world_biome_file_location = C::game_directory + "/biome_map.txt";
 const string C::room_directory = C::game_directory + "/rooms";
 const string C::user_data_directory = C::game_directory + "/user_data";
 
@@ -90,6 +89,10 @@ const string C::SWORD_ID = "sword";
 const string C::BOW_ID = "bow";
 const string C::TORCH_ID = "torch";
 const string C::HAMMER_ID = "hammer";
+
+// item IDs -> rocks and minerals
+const string C::IRON_ORE_ID = "iron ore";
+const string C::LIMESTONE_ID = "limestone";
 
 // commands
 const string C::BAD_COMMAND = "unknown_command";

--- a/IslandMUD-server/constants.h
+++ b/IslandMUD-server/constants.h
@@ -38,11 +38,11 @@ public:
 		DEFAULT_SPAWN_Z;
 
 	// game data locations
-	static const string game_directory;
-	static const string world_terrain_file_location;
-	static const string world_biome_file_location;
-	static const string room_directory;
-	static const string user_data_directory;
+	static const string
+		game_directory,
+		world_terrain_file_location,
+		room_directory,
+		user_data_directory;
 
 	// faction IDs
 	const static string PC_FACTION_ID; // players ("PCs")
@@ -85,7 +85,7 @@ public:
 		ARROWHEAD_ID,
 		BOARD_ID,
 
-		// item IDs -. other
+		// item IDs -> other
 		TREE_ID,
 		CHEST_ID,
 		LOG_ID,
@@ -97,6 +97,10 @@ public:
 		BOW_ID,
 		TORCH_ID,
 		HAMMER_ID,
+
+		// item IDs -> rocks and minerals
+		IRON_ORE_ID,
+		LIMESTONE_ID,
 
 		// commands
 		BAD_COMMAND,

--- a/IslandMUD-server/generator.h
+++ b/IslandMUD-server/generator.h
@@ -15,53 +15,41 @@ using namespace std;
 
 class Generator
 {
+public:
+
+	Generator(); // defined in class file
+
+	// generate a miniature map of the biomes
+	vector<vector<char_type>> generate_biome_map(const char_type & default_char, const char_type & fill_char,
+		const int & fill_ratio, const int & default_ratio, const int & biome_size);
+
+	// generate a full size map using static inside of each biome
+	vector<vector<char_type>> generate_static_using_biome_map(const vector<vector<char_type>> & biome_map, const int & biome_size);
+
+	// different pass types, all return by reference
+	void game_of_life(vector<vector<char_type>> & original, const int & iterations);
+	void clean(vector<vector<char_type>> & original, const int & iterations);
+	void fill(vector<vector<char_type>> & original, const int & iterations);
+
+	// save intermediate generated maps to /gen_[timestamp]/[pattern].txt
+	void save_intermediate_map(const vector<vector<char_type>> & v) const;
+
+	// save to custom location
+	void to_file(const vector<vector<char_type>> & v, const string & path) const;
+
+	string get_generator_pattern() const;
+	string get_generated_terrain_dir() const;
+
 private:
+
 	const int island_radius = (int)((double)C::WORLD_X_DIMENSION * .45); // assumes full map is square
 	const unsigned x_center = C::WORLD_X_DIMENSION / 2;
 	const unsigned y_center = C::WORLD_Y_DIMENSION / 2;
-	const int biome_size = 25;
 
 	stringstream generator_pattern; // reflects the steps used to reach a generated terrain
 
 	string generated_terrain_dir; // the path to place the terrain
 
-	vector<vector<char_type>> v1, v2, biome_map;
-
-public:
-
-	Generator()
-	{
-		cout << "\nGenerating new world terrain map...";
-
-		srand((unsigned)time(NULL)); // seed rand
-		
-		// create the timestamped directory
-		generated_terrain_dir = C::game_directory + "/gen_" + R::to_string(R::current_time_in_ms());
-		R::create_path_if_not_exists(generated_terrain_dir);
-
-		// fill both working vectors with empty space
-		size_vector(v1, C::WORLD_X_DIMENSION, C::WORLD_Y_DIMENSION);
-		size_vector(v2, C::WORLD_X_DIMENSION, C::WORLD_Y_DIMENSION);
-	}
-
-	void generate_biome_map();
-	void generate_static_using_biome_map();
-
-	// different pass types to call manually
-	void game_of_life(const int & iterations);
-	void clean(const int & iterations);
-	void fill(const int & iterations);
-
-	// two optional ways of getting the final result, either by saving the terrain to the disk, or by retriving it manually
-	void save_terrain() const;
-	vector<vector<char_type>> get_terrain();
-
-private:
-
-	void size_vector(vector<vector<char_type>> & v, const int & x, const int & y);
-
-	void save_current_terrain() const;
-	void to_file(const vector<vector<char_type>> & v, const string & dir) const;
 };
 
 #endif

--- a/IslandMUD-server/item.h
+++ b/IslandMUD-server/item.h
@@ -224,4 +224,16 @@ public:
 	Log() : Item(C::LOG_ID, false) {}
 };
 
+class Iron_Ore : public Item
+{
+public:
+	Iron_Ore() : Item(C::IRON_ORE_ID, false) {}
+};
+
+class Limestone : public Item
+{
+public:
+	Limestone() : Item(C::LIMESTONE_ID, false) {}
+};
+
 #endif

--- a/IslandMUD-server/main.cpp
+++ b/IslandMUD-server/main.cpp
@@ -11,6 +11,8 @@ using namespace std;
 
 int main()
 {
+	srand((unsigned)time(NULL)); // seed rand
+
 	// write game directories to disk
 	R::create_path_if_not_exists(C::game_directory);
 	R::create_path_if_not_exists(C::room_directory);
@@ -23,7 +25,7 @@ int main()
 	R::to_file(C::game_directory + "/" + "wipe delete folder.bat",
 		string("del /f/s/q C:/IslandMUD/delete > nul") + "\n" + "rmdir /s/q C:/IslandMUD/delete");
 #else
-	// add Linux equivalent
+	// add Linux equivalent?
 #endif
 
 	// create game object

--- a/IslandMUD-server/world.cpp
+++ b/IslandMUD-server/world.cpp
@@ -212,23 +212,50 @@ void World::load_terrain_map()
 
 	if (!terrain_loaded_from_file_good) // if the terrain needs to regenerated
 	{
-		// create the world generator object
+		// create the generator object
 		Generator gen;
 
-		gen.generate_biome_map();
-		gen.generate_static_using_biome_map();
+		// generate a biome map
+		vector<vector<char_type>> biome_map = gen.generate_biome_map(C::LAND_CHAR, C::FOREST_CHAR, 3, 1, 25); // hardcoding a bit here
+		gen.to_file(biome_map, gen.get_generated_terrain_dir() + "/biome_map.txt");
 
-		gen.game_of_life(5);
-		gen.fill(2);
-		gen.clean(3);
-		gen.fill(4); // this is the same as fill(12), but each call has a seperate printout this way
-		gen.fill(4);
-		gen.fill(4);
+		// use the biome map to generate static in a full size map
+		vector<vector<char_type>> world_map = gen.generate_static_using_biome_map(biome_map, 25); // hardcoding again
+		gen.to_file(world_map, gen.get_generated_terrain_dir() + "/static.txt");
+
+		gen.game_of_life(world_map, 5); gen.save_intermediate_map(world_map);
+		gen.fill(world_map, 2);  gen.save_intermediate_map(world_map);
+		gen.clean(world_map, 3); gen.save_intermediate_map(world_map);
+		gen.fill(world_map, 4);  gen.save_intermediate_map(world_map); // this is the same as fill(12), but each call has a seperate printout this way
+		gen.fill(world_map, 4);  gen.save_intermediate_map(world_map);
+		gen.fill(world_map, 4);  gen.save_intermediate_map(world_map);
 
 		// save the final terrain to disk
-		gen.save_terrain();
+		gen.to_file(world_map, C::world_terrain_file_location);
 
-		terrain = R::make_unique<std::vector<std::vector<char_type>>>(gen.get_terrain());
+		terrain = R::make_unique<vector<vector<char_type>>>(world_map);
+	}
+
+	// temporary scope - this is expirementation for mineral field generation, don't trust variable names yet
+	{
+		// create the generator object
+		Generator gen;
+
+		// generate a biome map
+		vector<vector<char_type>> biome_map = gen.generate_biome_map(C::LAND_CHAR, C::FOREST_CHAR, 1, 19, 25); // hardcoding a bit here
+		
+		// use the biome map to generate static in a full size map
+		vector<vector<char_type>> mineral_map = gen.generate_static_using_biome_map(biome_map, 25); // hardcoding again
+
+		gen.game_of_life(mineral_map, 5); gen.save_intermediate_map(mineral_map);
+		gen.fill(mineral_map, 2);  gen.save_intermediate_map(mineral_map);
+		gen.clean(mineral_map, 3); gen.save_intermediate_map(mineral_map);
+		gen.fill(mineral_map, 4);  gen.save_intermediate_map(mineral_map); // this is the same as fill(12), but each call has a seperate printout this way
+		gen.fill(mineral_map, 4);  gen.save_intermediate_map(mineral_map);
+		gen.fill(mineral_map, 4);  gen.save_intermediate_map(mineral_map);
+
+		// save the mineral map to disk
+		gen.to_file(mineral_map, C::game_directory + "/test_mineral_generation.txt");
 	}
 }
 


### PR DESCRIPTION
- overhauled Generator class for flexibility and reusability
(non-functional changes)
- add generation for mineral fields (these do not appear in the game
yet)
- added `Iron_Ore` and `Limestone` (these do not appear in the game yet)
- `rand()` is now seeded in `main`